### PR TITLE
fix: remove `on-main-branch-check` from publication workflow

### DIFF
--- a/.github/workflows/publish_fglatch.yml
+++ b/.github/workflows/publish_fglatch.yml
@@ -9,31 +9,8 @@ env:
   UV_VERSION: 0.8.3
 
 jobs:
-  on-main-branch-check:
-    runs-on: ubuntu-latest
-    outputs:
-      on_main: "${{ steps.contains_tag.outputs.retval }}"
-    steps:
-      # TODO: remove this and the `git branch -a` when the following PR
-      # is merged and released:
-      #   https://github.com/rickstaa/action-contains-tag/pull/18
-      - name: git config --global remote.origin.followRemoteHEAD never
-        run: git config --global remote.origin.followRemoteHEAD never
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: rickstaa/action-contains-tag@v1
-        id: contains_tag
-        with:
-          reference: "main"
-          tag: "\"${{ github.ref_name }}\""
-
   tests:
     name: tests
-    needs: on-main-branch-check
-    if: "${{ needs.on-main-branch-check.outputs.on_main == 'true' }}"
     uses: "./.github/workflows/python_package.yml"
 
   build-wheels:


### PR DESCRIPTION
## Summary

Removing the [currently broken](https://github.com/fulcrumgenomics/fglatch/actions/runs/16623043005/job/47032671157) main branch check from the PyPI publication workflow.