### PR TITLE
feat: add option to drop and log warnings for `EmptyCell` and `InvalidValue`

### DIFF
--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -89,14 +89,26 @@ class LatchRecordModel(BaseModel):
         record_name: str = record.get_name()
         values: dict[str, Any] = record.get_values()
 
-        # Check for any InvalidValue or EmptyCell values
+        # Check for any InvalidValue or EmptyCell values, and make a copy of the key/value pairs,
+        # excluding any that ought to be removed.
+        out_values: dict[str, Any] = {}
         keys_with_invalid_values: dict[str, Any] = {}
         keys_with_empty_cells: list[str] = []
         for key, value in values.items():
             if isinstance(value, InvalidValue):
                 keys_with_invalid_values[key] = value.raw_value
+                if not exclude_invalid_values:
+                    out_values[key] = value
             elif isinstance(value, EmptyCell):
                 keys_with_empty_cells.append(key)
+                if not exclude_empty_values:
+                    out_values[key] = value
+            elif isinstance(value, Record):
+                # Linked Record values are returned as Record objects, here we convert them to base
+                # `LatchRecordModel` instances.
+                out_values[key] = LatchRecordModel(id=value.id, name=value.get_name())
+            else:
+                out_values[key] = value
 
         if len(keys_with_invalid_values) > 0:
             invalid_value_fields: str = "\n".join(
@@ -112,21 +124,6 @@ class LatchRecordModel(BaseModel):
             logger.warning(
                 f"Empty cells found in record '{record_name}' for fields:\n\n{empty_cell_fields}"
             )
-
-        # Make a copy of the key/value pairs, excluding any that
-        out_values: dict[str, Any] = {}
-        for key, value in values.items():
-            if key in keys_with_invalid_values and exclude_invalid_values:
-                continue
-            if key in keys_with_empty_cells and exclude_empty_values:
-                continue
-
-            if isinstance(value, Record):
-                # Linked Record values are returned as Record objects, here we convert them to base
-                # `LatchRecordModel` instances.
-                out_values[key] = LatchRecordModel(id=value.id, name=value.get_name())
-            else:
-                out_values[key] = value
 
         # The record's name and ID are not included in the dictionary returned by
         # `Record.get_values()`, and they must be added manually.

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -1,10 +1,15 @@
+import logging
 from typing import Any
 from typing import Self
 
 from latch.registry.record import Record
 from latch.registry.table import Table
 from latch.registry.table import TableNotFoundError
+from latch.registry.types import EmptyCell
+from latch.registry.types import InvalidValue
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class LatchRecordModel(BaseModel):
@@ -47,7 +52,13 @@ class LatchRecordModel(BaseModel):
     name: str
 
     @classmethod
-    def from_record(cls, record: Record, table_id: str | None = None) -> Self:
+    def from_record(
+        cls,
+        record: Record,
+        table_id: str | None = None,
+        remove_empty_values: bool = False,
+        remove_invalid_values: bool = False,
+    ) -> Self:
         """
         Create a validated model instance from a Latch Registry Record.
 
@@ -57,6 +68,8 @@ class LatchRecordModel(BaseModel):
         Args:
             record: A record retrieved from a Latch Registry table via the SDK.
             table_id: An optional table ID to check the record against.
+            remove_empty_values: Removes record attributes with value `EmptyCell`.
+            remove_invalid_values: Removes record attributes with value `InvalidValue`.
 
         Returns:
             A validated instance of the model with all field data populated.
@@ -73,16 +86,33 @@ class LatchRecordModel(BaseModel):
         # Convert a Record to a dictionary.
         values: dict[str, Any] = record.get_values()
 
-        # Linked Record values are returned as Record objects, here we convert them to base
-        # `LatchRecordModel` instances.
-        for key, value in values.items():
-            if isinstance(value, Record):
-                values[key] = LatchRecordModel(id=value.id, name=value.get_name())
-
         # The record's name and ID are not included in the dictionary returned by
         # `Record.get_values()`, and they must be added manually.
         values["name"] = record.get_name()
         values["id"] = record.id
+
+        keys_to_remove: list[str] = []
+        for key, value in values.items():
+            if isinstance(value, Record):
+                # Linked Record values are returned as Record objects, here we convert them to base
+                # `LatchRecordModel` instances.
+                values[key] = LatchRecordModel(id=value.id, name=value.get_name())
+            elif isinstance(value, InvalidValue) and remove_invalid_values:
+                raw_value = value.raw_value
+                logger.warning(
+                    f"Invalid value for key '{key}' in record '{values['name']}': '{raw_value}'. "
+                    "The value will be removed from the record."
+                )
+                keys_to_remove.append(key)
+            elif isinstance(value, EmptyCell) and remove_empty_values:
+                logger.warning(
+                    f"Empty value for key '{key}' in record '{values['name']}': '{value}'. "
+                    "The value will be removed from the record."
+                )
+                keys_to_remove.append(key)
+
+        for key in keys_to_remove:
+            del values[key]
 
         return cls.model_validate(values)
 

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -84,12 +84,8 @@ class LatchRecordModel(BaseModel):
             _validate_source_table(record, table_id)
 
         # Convert a Record to a dictionary.
+        record_name: str = record.get_name()
         values: dict[str, Any] = record.get_values()
-
-        # The record's name and ID are not included in the dictionary returned by
-        # `Record.get_values()`, and they must be added manually.
-        values["name"] = record.get_name()
-        values["id"] = record.id
 
         keys_to_remove: list[str] = []
         for key, value in values.items():
@@ -100,19 +96,24 @@ class LatchRecordModel(BaseModel):
             elif isinstance(value, InvalidValue) and remove_invalid_values:
                 raw_value = value.raw_value
                 logger.warning(
-                    f"Invalid value for key '{key}' in record '{values['name']}': '{raw_value}'. "
+                    f"Invalid value for key '{key}' in record '{record_name}': '{raw_value}'. "
                     "The value will be removed from the record."
                 )
                 keys_to_remove.append(key)
             elif isinstance(value, EmptyCell) and remove_empty_values:
                 logger.warning(
-                    f"Empty value for key '{key}' in record '{values['name']}': '{value}'. "
+                    f"Empty value for key '{key}' in record '{record_name}': '{value}'. "
                     "The value will be removed from the record."
                 )
                 keys_to_remove.append(key)
 
         for key in keys_to_remove:
             del values[key]
+
+        # The record's name and ID are not included in the dictionary returned by
+        # `Record.get_values()`, and they must be added manually.
+        values["name"] = record_name
+        values["id"] = record.id
 
         return cls.model_validate(values)
 

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -169,20 +169,18 @@ def _classify_record_values(
     values: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
     """
-    Convert any raw record values required, and record invalid-value and empty-cell values.
-
-    Conversions
-    -----------
-    Linked `Record` instances in `converted_values` are replaced with base `LatchRecordModel`
-    instances.
+    Classify record values into converted values, invalid raw values, and empty-cell keys.
 
     Args:
       values: A dictionary mapping keys to values from a LatchRecord.
 
     Returns:
-        A tuple of (converted_values, invalid_raw_values_by_key, empty_cell_keys). `InvalidValue`
-        and `EmptyCell` sentinels are preserved in `converted_values` so the caller can decide
-        whether to exclude them.
+        A tuple of (converted, invalid, empty), where:
+            - `converted` contains all record values, with linked `Record` instances replaced by
+            base `LatchRecordModel` instances. `InvalidValue` and `EmptyCell` sentinels are
+            preserved as-is so the caller can decide whether to exclude them.
+            - `invalid` records the raw value for each `InvalidValue` encountered.
+            - `empty` lists the keys that mapped to an `EmptyCell`.
     """
     converted: dict[str, Any] = {}
     invalid: dict[str, Any] = {}

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -68,10 +68,10 @@ class LatchRecordModel(BaseModel):
         Args:
             record: A record retrieved from a Latch Registry table via the SDK.
             table_id: An optional table ID to check the record against.
-            exclude_invalid_values: If True, record attributes with value `InvalidValue` are
-                excluded prior to validation and a warning is logged.
             exclude_empty_values: If True, record attributes with value `EmptyCell` are excluded
                 prior to validation and a warning is logged.
+            exclude_invalid_values: If True, record attributes with value `InvalidValue` are
+                excluded prior to validation and a warning is logged.
 
         Returns:
             A validated instance of the model with all field data populated.
@@ -87,43 +87,31 @@ class LatchRecordModel(BaseModel):
 
         # Convert a Record to a dictionary.
         record_name: str = record.get_name()
-        values: dict[str, Any] = record.get_values()
+        converted_values, invalid_values, empty_cells = _classify_record_values(record.get_values())
 
-        # Check for any InvalidValue or EmptyCell values, and make a copy of the key/value pairs,
-        # excluding any that ought to be removed.
-        out_values: dict[str, Any] = {}
-        keys_with_invalid_values: dict[str, Any] = {}
-        keys_with_empty_cells: list[str] = []
-        for key, value in values.items():
-            if isinstance(value, InvalidValue):
-                keys_with_invalid_values[key] = value.raw_value
-                if not exclude_invalid_values:
-                    out_values[key] = value
-            elif isinstance(value, EmptyCell):
-                keys_with_empty_cells.append(key)
-                if not exclude_empty_values:
-                    out_values[key] = value
-            elif isinstance(value, Record):
-                # Linked Record values are returned as Record objects, here we convert them to base
-                # `LatchRecordModel` instances.
-                out_values[key] = LatchRecordModel(id=value.id, name=value.get_name())
-            else:
-                out_values[key] = value
-
-        if len(keys_with_invalid_values) > 0:
+        if len(invalid_values) > 0:
             invalid_value_fields: str = "\n".join(
-                f"{key}: {value}" for key, value in keys_with_invalid_values.items()
+                f"{key}: {value}" for key, value in invalid_values.items()
             )
             logger.warning(
                 f"Invalid values found in record '{record_name}' for fields:\n\n"
                 f"{invalid_value_fields}"
             )
 
-        if len(keys_with_empty_cells) > 0:
-            empty_cell_fields: str = "\n".join(keys_with_empty_cells)
+        if len(empty_cells) > 0:
+            empty_cell_fields: str = "\n".join(empty_cells)
             logger.warning(
                 f"Empty cells found in record '{record_name}' for fields:\n\n{empty_cell_fields}"
             )
+
+        # Check for any InvalidValue or EmptyCell values, and make a copy of the key/value pairs,
+        # excluding any that ought to be removed.
+        out_values: dict[str, Any] = {
+            key: value
+            for key, value in converted_values.items()
+            if not (exclude_invalid_values and key in invalid_values)
+            and not (exclude_empty_values and key in empty_cells)
+        }
 
         # The record's name and ID are not included in the dictionary returned by
         # `Record.get_values()`, and they must be added manually.
@@ -175,3 +163,41 @@ def _validate_source_table(record: Record, table_id: str) -> None:
             f"Record {record.get_name()} (id={record.id}) originated from "
             f"table {record_table_name} (id={record_table_id})."
         )
+
+
+def _classify_record_values(
+    values: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """
+    Convert any raw record values required, and record invalid-value and empty-cell values.
+
+    Conversions
+    -----------
+    Linked `Record` instances in `converted_values` are replaced with base `LatchRecordModel`
+    instances.
+
+    Args:
+      values: A dictionary mapping keys to values from a LatchRecord.
+
+    Returns:
+        A tuple of (converted_values, invalid_raw_values_by_key, empty_cell_keys). `InvalidValue`
+        and `EmptyCell` sentinels are preserved in `converted_values` so the caller can decide
+        whether to exclude them.
+    """
+    converted: dict[str, Any] = {}
+    invalid: dict[str, Any] = {}
+    empty: list[str] = []
+
+    for key, value in values.items():
+        if isinstance(value, InvalidValue):
+            invalid[key] = value.raw_value
+            converted[key] = value
+        elif isinstance(value, EmptyCell):
+            empty.append(key)
+            converted[key] = value
+        elif isinstance(value, Record):
+            converted[key] = LatchRecordModel(id=value.id, name=value.get_name())
+        else:
+            converted[key] = value
+
+    return converted, invalid, empty

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -52,12 +52,12 @@ class LatchRecordModel(BaseModel):
     name: str
 
     @classmethod
-    def from_record(
+    def from_record(  # noqa: C901
         cls,
         record: Record,
         table_id: str | None = None,
-        remove_empty_values: bool = False,
-        remove_invalid_values: bool = False,
+        exclude_empty_values: bool = False,
+        exclude_invalid_values: bool = False,
     ) -> Self:
         """
         Create a validated model instance from a Latch Registry Record.
@@ -68,8 +68,10 @@ class LatchRecordModel(BaseModel):
         Args:
             record: A record retrieved from a Latch Registry table via the SDK.
             table_id: An optional table ID to check the record against.
-            remove_empty_values: Removes record attributes with value `EmptyCell`.
-            remove_invalid_values: Removes record attributes with value `InvalidValue`.
+            exclude_invalid_values: If True, record attributes with value `InvalidValue` are
+                excluded prior to validation and a warning is logged.
+            exclude_empty_values: If True, record attributes with value `EmptyCell` are excluded
+                prior to validation and a warning is logged.
 
         Returns:
             A validated instance of the model with all field data populated.
@@ -87,35 +89,51 @@ class LatchRecordModel(BaseModel):
         record_name: str = record.get_name()
         values: dict[str, Any] = record.get_values()
 
-        keys_to_remove: list[str] = []
+        # Check for any InvalidValue or EmptyCell values
+        keys_with_invalid_values: dict[str, Any] = {}
+        keys_with_empty_cells: list[str] = []
         for key, value in values.items():
+            if isinstance(value, InvalidValue):
+                keys_with_invalid_values[key] = value.raw_value
+            elif isinstance(value, EmptyCell):
+                keys_with_empty_cells.append(key)
+
+        if len(keys_with_invalid_values) > 0:
+            invalid_value_fields: str = "\n".join(
+                f"{key}: {value}" for key, value in keys_with_invalid_values.items()
+            )
+            logger.warning(
+                f"Invalid values found in record '{record_name}' for fields:\n\n"
+                f"{invalid_value_fields}"
+            )
+
+        if len(keys_with_empty_cells) > 0:
+            empty_cell_fields: str = "\n".join(keys_with_empty_cells)
+            logger.warning(
+                f"Empty cells found in record '{record_name}' for fields:\n\n{empty_cell_fields}"
+            )
+
+        # Make a copy of the key/value pairs, excluding any that
+        out_values: dict[str, Any] = {}
+        for key, value in values.items():
+            if key in keys_with_invalid_values and exclude_invalid_values:
+                continue
+            if key in keys_with_empty_cells and exclude_empty_values:
+                continue
+
             if isinstance(value, Record):
                 # Linked Record values are returned as Record objects, here we convert them to base
                 # `LatchRecordModel` instances.
-                values[key] = LatchRecordModel(id=value.id, name=value.get_name())
-            elif isinstance(value, InvalidValue) and remove_invalid_values:
-                raw_value = value.raw_value
-                logger.warning(
-                    f"Invalid value for key '{key}' in record '{record_name}': '{raw_value}'. "
-                    "The value will be removed from the record."
-                )
-                keys_to_remove.append(key)
-            elif isinstance(value, EmptyCell) and remove_empty_values:
-                logger.warning(
-                    f"Empty value for key '{key}' in record '{record_name}': '{value}'. "
-                    "The value will be removed from the record."
-                )
-                keys_to_remove.append(key)
-
-        for key in keys_to_remove:
-            del values[key]
+                out_values[key] = LatchRecordModel(id=value.id, name=value.get_name())
+            else:
+                out_values[key] = value
 
         # The record's name and ID are not included in the dictionary returned by
         # `Record.get_values()`, and they must be added manually.
-        values["name"] = record_name
-        values["id"] = record.id
+        out_values["name"] = record_name
+        out_values["id"] = record.id
 
-        return cls.model_validate(values)
+        return cls.model_validate(out_values)
 
 
 def _safe_table_name(table_id: str) -> str | None:

--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -52,7 +52,7 @@ class LatchRecordModel(BaseModel):
     name: str
 
     @classmethod
-    def from_record(  # noqa: C901
+    def from_record(
         cls,
         record: Record,
         table_id: str | None = None,

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -2,6 +2,9 @@ import pytest
 from latch.registry.record import Record
 from latch.registry.table import Table
 from latch.registry.table import TableNotFoundError
+from latch.registry.types import EmptyCell
+from latch.registry.types import InvalidValue
+from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from fglatch.registry import LatchRecordModel
@@ -128,3 +131,86 @@ def test_skip_linked_record_online() -> None:
 
     assert transcript.name == transcript_record_name
     assert transcript.shortname == "NOTCH1-204"
+
+
+def test_from_record_remove_empty_values(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """EmptyCell values should be dropped and a warning logged when remove_empty_values=True."""
+    import logging
+
+    class SampleRecord(LatchRecordModel):
+        sample_name: str
+        concentration: float | None = None
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "42"
+    mock_record.get_name.return_value = "sample_001"
+    mock_record.get_values.return_value = {
+        "sample_name": "my_sample",
+        "concentration": mocker.MagicMock(spec=EmptyCell),
+    }
+
+    with caplog.at_level(logging.WARNING, logger="fglatch.registry._record_model"):
+        result = SampleRecord.from_record(mock_record, remove_empty_values=True)
+
+    assert result.id == "42"
+    assert result.name == "sample_001"
+    assert result.sample_name == "my_sample"
+    assert result.concentration is None
+    assert any("concentration" in msg for msg in caplog.messages)
+    assert any("Empty value" in msg for msg in caplog.messages)
+
+
+def test_from_record_remove_invalid_values(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """InvalidValue values should be dropped and a warning logged if remove_invalid_values=True."""
+    import logging
+
+    class SampleRecord(LatchRecordModel):
+        sample_name: str
+        concentration: float | None = None
+
+    mock_invalid = mocker.MagicMock(spec=InvalidValue)
+    mock_invalid.raw_value = "not_a_float"
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "42"
+    mock_record.get_name.return_value = "sample_001"
+    mock_record.get_values.return_value = {
+        "sample_name": "my_sample",
+        "concentration": mock_invalid,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="fglatch.registry._record_model"):
+        result = SampleRecord.from_record(mock_record, remove_invalid_values=True)
+
+    assert result.id == "42"
+    assert result.name == "sample_001"
+    assert result.sample_name == "my_sample"
+    assert result.concentration is None
+    assert any("concentration" in msg for msg in caplog.messages)
+    assert any("Invalid value" in msg for msg in caplog.messages)
+
+
+@pytest.mark.requires_latch_registry
+def test_from_record_remove_empty_values_raises_online() -> None:
+    """Removing an EmptyCell for a required field should raise a ValidationError."""
+
+    class Transcript(LatchRecordModel):
+        """Represent a record from the Transcript table."""
+
+        shortname: str
+        gene: LatchRecordModel
+
+    transcript_table_id = "12146"
+    transcript_record_name = "ENST00000123456.1"
+
+    records = query_latch_records_by_name(transcript_record_name, table_id=transcript_table_id)
+    assert len(records) == 1
+
+    record = records[transcript_record_name]
+
+    with pytest.raises(ValidationError):
+        Transcript.from_record(record, table_id=transcript_table_id, remove_empty_values=True)

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -159,7 +159,9 @@ def test_from_record_exclude_empty_values(
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
-    assert any("Empty cells found in record 'sample_001' for fields:\n\nconcentration")
+
+    expected_warning: str = "Empty cells found in record 'sample_001' for fields:\n\nconcentration"
+    assert any(expected_warning in msg for msg in caplog.messages)
 
 
 def test_from_record_exclude_invalid_values(
@@ -189,11 +191,11 @@ def test_from_record_exclude_invalid_values(
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
-    assert any(
+
+    expected_warning: str = (
         "Invalid values found in record 'sample_001' for fields:\n\nconcentration: not_a_float"
-        in msg
-        for msg in caplog.messages
     )
+    assert any(expected_warning in msg for msg in caplog.messages)
 
 
 def test_from_record_exclude_invalid_values_and_empty_cells(
@@ -232,12 +234,15 @@ def test_from_record_exclude_invalid_values_and_empty_cells(
     assert result.sample_name == "my_sample"
     assert result.concentration is None
     assert result.experiment_id is None
-    assert any(
+
+    expected_invalid_value_warning: str = (
         "Invalid values found in record 'sample_001' for fields:\n\nconcentration: not_a_float"
-        in msg
-        for msg in caplog.messages
     )
-    assert any("Empty cells found in record 'sample_001' for fields:\n\nexperiment_id")
+    expected_empty_cell_warning: str = (
+        "Empty cells found in record 'sample_001' for fields:\n\nexperiment_id"
+    )
+    assert any(expected_invalid_value_warning in msg for msg in caplog.messages)
+    assert any(expected_empty_cell_warning in msg for msg in caplog.messages)
 
 
 def test_from_record_invalid_value_raises_error(mocker: MockerFixture) -> None:

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import pytest
 from latch.registry.record import Record
@@ -11,6 +12,7 @@ from pytest_mock import MockerFixture
 
 from fglatch.registry import LatchRecordModel
 from fglatch.registry import query_latch_records_by_name
+from fglatch.registry._record_model import _classify_record_values
 from fglatch.registry._record_model import _safe_table_name
 from fglatch.registry._record_model import _validate_source_table
 from tests.constants import MOCK_RECORD_1_ID
@@ -320,3 +322,38 @@ def test_from_record_exclude_empty_values_raises_online() -> None:
 
     with pytest.raises(ValidationError):
         Transcript.from_record(record, table_id=transcript_table_id, exclude_empty_values=True)
+
+
+def test_classify_record_values(mocker: MockerFixture) -> None:
+    """Test that record values are correctly converted and classified."""
+    mock_linked_record = mocker.MagicMock(spec=Record)
+    mock_linked_record.get_table_id.return_value = "1234"
+    mock_linked_record.id = "123"
+    mock_linked_record.get_name.return_value = "DNA123/seq_abc"
+
+    mock_invalid = mocker.MagicMock(spec=InvalidValue)
+    mock_invalid.raw_value = "not_a_float"
+
+    mock_empty_cell = mocker.MagicMock(spec=EmptyCell)
+
+    values: dict[str, Any] = {
+        "sample_name": "my_sample",
+        "concentration": mock_invalid,
+        "experiment_id": mock_empty_cell,
+        "sequence": mock_linked_record,
+    }
+
+    converted_values, invalid_values, empty_cells = _classify_record_values(values)
+
+    # The linked record should be converted into a LatchRecordModel
+    assert converted_values["sample_name"] == "my_sample"
+    assert converted_values["concentration"] == mock_invalid
+    assert converted_values["experiment_id"] == mock_empty_cell
+    assert converted_values["sequence"] == LatchRecordModel(id="123", name="DNA123/seq_abc")
+
+    # Invalid value entries should have the raw value recorded here
+    assert len(invalid_values) == 1
+    assert invalid_values["concentration"] == "not_a_float"
+
+    assert len(empty_cells) == 1
+    assert empty_cells[0] == "experiment_id"

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from latch.registry.record import Record
 from latch.registry.table import Table
@@ -133,11 +135,10 @@ def test_skip_linked_record_online() -> None:
     assert transcript.shortname == "NOTCH1-204"
 
 
-def test_from_record_remove_empty_values(
+def test_from_record_exclude_empty_values(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     """EmptyCell values should be dropped and a warning logged when remove_empty_values=True."""
-    import logging
 
     class SampleRecord(LatchRecordModel):
         sample_name: str
@@ -152,21 +153,20 @@ def test_from_record_remove_empty_values(
     }
 
     with caplog.at_level(logging.WARNING, logger="fglatch.registry._record_model"):
-        result = SampleRecord.from_record(mock_record, remove_empty_values=True)
+        result = SampleRecord.from_record(mock_record, exclude_empty_values=True)
 
     assert result.id == "42"
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
     assert any("concentration" in msg for msg in caplog.messages)
-    assert any("Empty value" in msg for msg in caplog.messages)
+    assert any("Empty cells found" in msg for msg in caplog.messages)
 
 
-def test_from_record_remove_invalid_values(
+def test_from_record_exclude_invalid_values(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     """InvalidValue values should be dropped and a warning logged if remove_invalid_values=True."""
-    import logging
 
     class SampleRecord(LatchRecordModel):
         sample_name: str
@@ -184,18 +184,18 @@ def test_from_record_remove_invalid_values(
     }
 
     with caplog.at_level(logging.WARNING, logger="fglatch.registry._record_model"):
-        result = SampleRecord.from_record(mock_record, remove_invalid_values=True)
+        result = SampleRecord.from_record(mock_record, exclude_invalid_values=True)
 
     assert result.id == "42"
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
     assert any("concentration" in msg for msg in caplog.messages)
-    assert any("Invalid value" in msg for msg in caplog.messages)
+    assert any("Invalid values found" in msg for msg in caplog.messages)
 
 
 @pytest.mark.requires_latch_registry
-def test_from_record_remove_empty_values_raises_online() -> None:
+def test_from_record_exclude_empty_values_raises_online() -> None:
     """Removing an EmptyCell for a required field should raise a ValidationError."""
 
     class Transcript(LatchRecordModel):
@@ -213,4 +213,4 @@ def test_from_record_remove_empty_values_raises_online() -> None:
     record = records[transcript_record_name]
 
     with pytest.raises(ValidationError):
-        Transcript.from_record(record, table_id=transcript_table_id, remove_empty_values=True)
+        Transcript.from_record(record, table_id=transcript_table_id, exclude_empty_values=True)

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -138,7 +138,7 @@ def test_skip_linked_record_online() -> None:
 def test_from_record_exclude_empty_values(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """EmptyCell values should be dropped and a warning logged when remove_empty_values=True."""
+    """EmptyCell values should be dropped and a warning logged when exclude_empty_values=True."""
 
     class SampleRecord(LatchRecordModel):
         sample_name: str
@@ -159,14 +159,13 @@ def test_from_record_exclude_empty_values(
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
-    assert any("concentration" in msg for msg in caplog.messages)
-    assert any("Empty cells found" in msg for msg in caplog.messages)
+    assert any("Empty cells found in record 'sample_001' for fields:\n\nconcentration")
 
 
 def test_from_record_exclude_invalid_values(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """InvalidValue values should be dropped and a warning logged if remove_invalid_values=True."""
+    """InvalidValue values should be dropped and a warning logged if exclude_invalid_values=True."""
 
     class SampleRecord(LatchRecordModel):
         sample_name: str
@@ -190,8 +189,110 @@ def test_from_record_exclude_invalid_values(
     assert result.name == "sample_001"
     assert result.sample_name == "my_sample"
     assert result.concentration is None
-    assert any("concentration" in msg for msg in caplog.messages)
-    assert any("Invalid values found" in msg for msg in caplog.messages)
+    assert any(
+        "Invalid values found in record 'sample_001' for fields:\n\nconcentration: not_a_float"
+        in msg
+        for msg in caplog.messages
+    )
+
+
+def test_from_record_exclude_invalid_values_and_empty_cells(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    InvalidValue values should be dropped and a warning logged if exclude_invalid_values=True.
+
+    EmptyCell values should be dropped and a warning logged when exclude_empty_values=True.
+    """
+
+    class SampleRecord(LatchRecordModel):
+        sample_name: str
+        concentration: float | None = None
+        experiment_id: str | None = None
+
+    mock_invalid = mocker.MagicMock(spec=InvalidValue)
+    mock_invalid.raw_value = "not_a_float"
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "42"
+    mock_record.get_name.return_value = "sample_001"
+    mock_record.get_values.return_value = {
+        "sample_name": "my_sample",
+        "concentration": mock_invalid,
+        "experiment_id": mocker.MagicMock(spec=EmptyCell),
+    }
+
+    with caplog.at_level(logging.WARNING, logger="fglatch.registry._record_model"):
+        result = SampleRecord.from_record(
+            mock_record, exclude_invalid_values=True, exclude_empty_values=True
+        )
+
+    assert result.id == "42"
+    assert result.name == "sample_001"
+    assert result.sample_name == "my_sample"
+    assert result.concentration is None
+    assert result.experiment_id is None
+    assert any(
+        "Invalid values found in record 'sample_001' for fields:\n\nconcentration: not_a_float"
+        in msg
+        for msg in caplog.messages
+    )
+    assert any("Empty cells found in record 'sample_001' for fields:\n\nexperiment_id")
+
+
+def test_from_record_invalid_value_raises_error(mocker: MockerFixture) -> None:
+    """InvalidValue values should raise an error if exclude_invalid_values=False."""
+
+    class SampleRecord(LatchRecordModel):
+        sample_name: str
+        concentration: float | None = None
+
+    mock_invalid = mocker.MagicMock(spec=InvalidValue)
+    mock_invalid.raw_value = "not_a_float"
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "42"
+    mock_record.get_name.return_value = "sample_001"
+    mock_record.get_values.return_value = {
+        "sample_name": "my_sample",
+        "concentration": mock_invalid,
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "1 validation error for SampleRecord\nconcentration\n  Input should be a valid number"
+        ),
+    ):
+        SampleRecord.from_record(
+            mock_record, exclude_invalid_values=False, exclude_empty_values=False
+        )
+
+
+def test_from_record_empty_value_raises_error(mocker: MockerFixture) -> None:
+    """InvalidValue values should raise an error if exclude_empty_values=False."""
+
+    class SampleRecord(LatchRecordModel):
+        sample_name: str
+        concentration: float | None = None
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "42"
+    mock_record.get_name.return_value = "sample_001"
+    mock_record.get_values.return_value = {
+        "sample_name": "my_sample",
+        "concentration": mocker.MagicMock(spec=EmptyCell),
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "1 validation error for SampleRecord\nconcentration\n  Input should be a valid number"
+        ),
+    ):
+        SampleRecord.from_record(
+            mock_record, exclude_invalid_values=False, exclude_empty_values=False
+        )
 
 
 @pytest.mark.requires_latch_registry

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -277,7 +277,7 @@ def test_from_record_invalid_value_raises_error(mocker: MockerFixture) -> None:
 
 
 def test_from_record_empty_value_raises_error(mocker: MockerFixture) -> None:
-    """InvalidValue values should raise an error if exclude_empty_values=False."""
+    """EmptyCell values should raise an error if exclude_empty_values=False."""
 
     class SampleRecord(LatchRecordModel):
         sample_name: str


### PR DESCRIPTION
## Summary

Add two opt-in flags to `LatchRecordModel.from_record` that let callers drop `InvalidValue` and `EmptyCell` entries before pydantic validation, and log a warning listing the affected fields. This is useful when an optional field on a model has a bad/empty cell in the Registry — without these flags, validation fails on data the caller explicitly treats as optional.

## Changes

- **`from_record` gains two kwargs** (default `False`, preserving existing behavior):
  - `exclude_invalid_values` — drop keys whose value is `InvalidValue`
  - `exclude_empty_values` — drop keys whose value is `EmptyCell`
- When either kind of sentinel is present (regardless of whether it's dropped), a single `WARNING` is logged per category listing the affected fields and, for invalid values, the raw value that failed parsing.
- Scanning for sentinels, converting linked `Record` objects to `LatchRecordModel`, and building the output dict are now done in a single pass instead of two.
- `id`/`name` are now added to the output dict after the value loop (previously they were injected into the input dict, which made them visible to the scan loop).
