### PR TITLE
chore(release): bump to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "fglatch"
-version         = "0.4.0"
+version         = "0.5.0"
 description     = "CLI and Python extensions for the LatchBio platform."
 readme          = "README.md"
 authors         = [{ name="Fulcrum Genomics LLC", email="contact@fulcrumgenomics.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "fglatch"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
Prep 0.5.0 release. Since 0.4.0:

- feat: add option to drop and log warnings for `EmptyCell` and `InvalidValue` (#37)
- chore: bump `requests_ratelimiter` to 0.9 (#38)
- chore: fix all GHAs to commit tags and bump to latest versions (#40)

The `requests_ratelimiter` bump resolves an `ImportError` for `RequestRate` seen in downstream toolkits. The `LatchRecordModel.from_record` additions (`exclude_invalid_values`, `exclude_empty_values`) default to `False`, so existing callers are unaffected.

## Test plan

- `uv run poe fix-and-check-all` passes locally (52 passed, 3 xfailed — online tests require Fulcrum workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)