### PR TITLE
fix(deps): bump pyrate-limiter pin to >=4.1,<5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies    = [
     "pydantic~=2.11",
     "pytest-asyncio>=1.2.0",
     "requests~=2.31",
-    "requests-ratelimiter~=0.9",
-    "pyrate-limiter~=4.0.2",
+    "requests-ratelimiter>=0.9,<1",
+    "pyrate-limiter>=4.1,<5",
     "xattr~=1.1",
 ]
 classifiers     = [

--- a/uv.lock
+++ b/uv.lock
@@ -583,10 +583,10 @@ requires-dist = [
     { name = "defopt", specifier = "~=6.4" },
     { name = "latch", specifier = ">=2.67.2,<3" },
     { name = "pydantic", specifier = "~=2.11" },
-    { name = "pyrate-limiter", specifier = "~=4.0.2" },
+    { name = "pyrate-limiter", specifier = ">=4.1,<5" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "requests", specifier = "~=2.31" },
-    { name = "requests-ratelimiter", specifier = "~=0.9" },
+    { name = "requests-ratelimiter", specifier = ">=0.9,<1" },
     { name = "xattr", specifier = "~=1.1" },
 ]
 
@@ -1668,11 +1668,11 @@ wheels = [
 
 [[package]]
 name = "pyrate-limiter"
-version = "4.0.2"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/98/2b3dc1ba6bdf2efaeaa3e102124cbd2636a4ccec241ffeb8a1de207f5cd4/pyrate_limiter-4.0.2.tar.gz", hash = "sha256:b678841e2215f114ef6f98c7093755ca3b466de83cb5a881231fd6e321fa14b5", size = 301304, upload-time = "2026-01-23T09:37:33.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/0c/6e78218e6ef726be35a4c0a5e2e281e36ddd940566800219e96d13de99ad/pyrate_limiter-4.1.0.tar.gz", hash = "sha256:be1ac413a263aa410b98757d1b01a880650948a1fc3a959512f15865eb58dbf3", size = 306136, upload-time = "2026-03-22T14:43:03.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b9/80ffe3f2c34d3247186d74b1d08c1fed1e3ad4127ff6a8a5501b7bf16a97/pyrate_limiter-4.0.2-py3-none-any.whl", hash = "sha256:35ec42b9bb9cfabcafab14d0c5c6523f48378c3da2949e534ce3cbdfea71eadd", size = 36439, upload-time = "2026-01-23T09:37:32.097Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/fd/57181fafae08385d00ea2702be246ab8035352a0a8e1f63391c2bcad74d4/pyrate_limiter-4.1.0-py3-none-any.whl", hash = "sha256:2696b4e4a6cffb3d40fc76662baccb766697893f0979e12bebbfc7d3b6b19603", size = 38197, upload-time = "2026-03-22T14:43:01.975Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #43

The current pins are mutually unsatisfiable:

- `requests-ratelimiter~=0.9` allows up to `0.10.x`
- `pyrate-limiter~=4.0.2` caps at `<4.1`

But `requests-ratelimiter>=0.9.3` requires `pyrate-limiter>=4.1,<5`, so any solver that picks `0.9.3` or `0.10.0` fails. This blocks the bioconda recipe (`pip check` failure on the conda-forge build).

Switch both pins to explicit `>=,<` ranges — `~=4.0.2` reading like "compatible with 4.0.2" but actually meaning `<4.1` is what caused the conflict.

**No code change needed.** fglatch only uses `Rate`, `Limiter`, `Duration` from pyrate-limiter (`fglatch/_client/latch_client.py`), and their signatures are identical between 4.0.2 and 4.1.0.

## Test plan

- `uv run poe fix-and-check-all` passes locally with the new resolved versions (52 passed, 3 xfailed — online tests require Fulcrum workspace).
- `uv lock` resolves cleanly to `pyrate-limiter 4.1.0`.