### PR TITLE
chore(release): bump to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "fglatch"
-version         = "0.5.0"
+version         = "0.6.0"
 description     = "CLI and Python extensions for the LatchBio platform."
 readme          = "README.md"
 authors         = [{ name="Fulcrum Genomics LLC", email="contact@fulcrumgenomics.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "fglatch"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "defopt" },


### PR DESCRIPTION
Prep 0.6.0 release. Since 0.5.0:

- fix(deps): bump `pyrate-limiter` pin to `>=4.1,<5` (#43)
- feat(cli): add `--version` flag (#46)

The dep-pin fix unblocks the bioconda recipe — the prior `~=4.0.2` / `~=0.9` combination was mutually unsatisfiable with `requests-ratelimiter>=0.9.3`, causing `pip check` failures downstream. The `--version` flag adds a new public surface (`fglatch.__version__` and `fglatch --version`), which is why this is a minor bump rather than a patch.

## Test plan

- `uv run poe fix-and-check-all` passes locally on the resolved 0.6.0 environment (53 passed, 3 xfailed — online tests require Fulcrum workspace).
- `fglatch --version` prints `0.6.0`.