### PR TITLE
feat(registry): add schema validation dispatcher + missing/extra columns

### DIFF
--- a/fglatch/registry/_schema.py
+++ b/fglatch/registry/_schema.py
@@ -1,11 +1,16 @@
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 # TODO: switch to the public re-export once fgmetric promotes these symbols
 # out of `_typing_extensions`.
 from fgmetric._typing_extensions import TypeAnnotation
+from latch.registry.table import Table
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import computed_field
+
+if TYPE_CHECKING:
+    from fglatch.registry._record_model import LatchRecordModel
 
 
 class SchemaMismatchKind(StrEnum):
@@ -144,3 +149,65 @@ def _render(annotation: TypeAnnotation | None) -> str:
     else:
         rendered = str(annotation)
     return rendered
+
+
+_SKIPPED_MODEL_FIELDS: frozenset[str] = frozenset({"id", "name"})
+"""Record metadata fields on `LatchRecordModel`; not Registry columns, so not validated."""
+
+
+def _validate_table_schema(
+    model_cls: "type[LatchRecordModel]",
+    table: Table,
+    *,
+    allow_extra_columns: bool,
+) -> list[SchemaMismatch]:
+    """
+    Compare a `LatchRecordModel`'s declared schema to a live Registry `Table`.
+
+    Enumerates the model's `model_fields` (excluding the base `id` / `name`) and the
+    table's columns; reports `missing_on_table` for declared fields with no matching
+    column, and (when `allow_extra_columns=False`) `missing_on_model` for columns the
+    model does not declare.
+
+    Args:
+        model_cls: A `LatchRecordModel` subclass whose `model_fields` are compared.
+        table: A Registry table whose columns are inspected. The caller is responsible
+            for calling `table.load()` before passing it in.
+        allow_extra_columns: If False, columns present on the table but not declared on
+            the model produce `missing_on_model` errors.
+
+    Returns:
+        One `SchemaMismatch` per detected disagreement. Empty list when the schema matches.
+    """
+    mismatches: list[SchemaMismatch] = []
+    columns = table.get_columns()
+
+    model_annotations: dict[str, TypeAnnotation] = {
+        name: info.annotation
+        for name, info in model_cls.model_fields.items()
+        if name not in _SKIPPED_MODEL_FIELDS and info.annotation is not None
+    }
+
+    for field_name, annotation in model_annotations.items():
+        if field_name not in columns:
+            mismatches.append(
+                SchemaMismatch(
+                    kind=SchemaMismatchKind.MISSING_ON_TABLE,
+                    model_field=field_name,
+                    model_type=annotation,
+                )
+            )
+
+    if not allow_extra_columns:
+        for column_name, column in columns.items():
+            if column_name in model_annotations:
+                continue
+            mismatches.append(
+                SchemaMismatch(
+                    kind=SchemaMismatchKind.MISSING_ON_MODEL,
+                    column_name=column_name,
+                    column_type=column.type,
+                )
+            )
+
+    return mismatches

--- a/tests/registry/test_schema.py
+++ b/tests/registry/test_schema.py
@@ -1,8 +1,43 @@
-import pytest
+from typing import Any
+from typing import Literal
+from typing import Union
+from typing import cast
 
+import pytest
+from latch.registry.table import Table
+from latch.registry.types import Column
+from latch.registry.types import EmptyCell
+from latch.registry.upstream_types.types import DBType
+from pytest_mock import MockerFixture
+
+from fglatch.registry import LatchRecordModel
 from fglatch.registry import RegistryTableSchemaError
 from fglatch.registry import SchemaMismatch
 from fglatch.registry import SchemaMismatchKind
+from fglatch.registry._schema import _validate_table_schema
+
+_BasicPrimitive = Literal["string", "integer", "number", "boolean", "date", "datetime"]
+
+
+def _column(py_type: Any, primitive: _BasicPrimitive, allow_empty: bool = False) -> Column:
+    """Construct a realistic Column. The `key` is overwritten by `_table` below."""
+    column_type: Any = Union[py_type, EmptyCell] if allow_empty else py_type
+    upstream_type: DBType = {
+        "type": {"primitive": primitive},
+        "allowEmpty": allow_empty,
+    }
+    return Column(key="<placeholder>", type=column_type, upstream_type=upstream_type)
+
+
+def _table(mocker: MockerFixture, columns: dict[str, Column]) -> Table:
+    """Build a mock Table whose `get_columns()` returns `columns` with matching keys."""
+    keyed: dict[str, Column] = {
+        name: Column(key=name, type=col.type, upstream_type=col.upstream_type)
+        for name, col in columns.items()
+    }
+    table = mocker.MagicMock(spec=Table)
+    table.get_columns.return_value = keyed
+    return cast(Table, table)
 
 
 def test_kind_str_enum_values() -> None:
@@ -93,3 +128,102 @@ def test_registry_table_schema_error_message_aggregates_mismatches() -> None:
         "Field 'y' (float) is declared on the model but the table has no matching column."
         in rendered
     )
+
+
+# _validate_table_schema tests — enumeration (missing on each side).
+
+
+def test_no_mismatches_when_dispatcher_finds_no_missing_fields(mocker: MockerFixture) -> None:
+    """
+    A model whose fields all exist on the table produces no enumeration mismatches.
+
+    Per-field type comparison is added in a later commit, so this test does not yet
+    require columns and model annotations to agree on type.
+    """
+
+    class Model(LatchRecordModel):
+        x: str
+        y: int
+
+    table = _table(
+        mocker,
+        {"x": _column(str, "string"), "y": _column(int, "integer")},
+    )
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_missing_on_table(mocker: MockerFixture) -> None:
+    """A model field with no matching column produces `missing_on_table`."""
+
+    class Model(LatchRecordModel):
+        not_there: str
+
+    mismatches = _validate_table_schema(Model, _table(mocker, {}), allow_extra_columns=True)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.MISSING_ON_TABLE
+    assert mismatches[0].model_field == "not_there"
+    assert mismatches[0].model_type is str
+    assert mismatches[0].column_name is None
+    assert mismatches[0].column_type is None
+
+
+def test_missing_on_model_silent_by_default(mocker: MockerFixture) -> None:
+    """Columns the model doesn't declare are silent when `allow_extra_columns=True`."""
+
+    class Model(LatchRecordModel):
+        pass
+
+    table = _table(mocker, {"extra_col": _column(str, "string")})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_missing_on_model_when_strict(mocker: MockerFixture) -> None:
+    """Columns the model doesn't declare error when `allow_extra_columns=False`."""
+
+    class Model(LatchRecordModel):
+        pass
+
+    table = _table(mocker, {"extra_col": _column(str, "string")})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=False)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.MISSING_ON_MODEL
+    assert mismatches[0].column_name == "extra_col"
+    assert mismatches[0].column_type is str
+    assert mismatches[0].model_field is None
+    assert mismatches[0].model_type is None
+
+
+def test_id_and_name_are_skipped(mocker: MockerFixture) -> None:
+    """The base model's `id` and `name` are not validated against table columns."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    # Table has no `id` / `name` columns, yet the model validates cleanly.
+    assert (
+        _validate_table_schema(
+            Model,
+            _table(mocker, {"x": _column(str, "string")}),
+            allow_extra_columns=True,
+        )
+        == []
+    )
+
+
+def test_multiple_mismatches_collected(mocker: MockerFixture) -> None:
+    """Multiple disagreements surface together, not one-at-a-time."""
+
+    class Model(LatchRecordModel):
+        on_model_only: str
+
+    table = _table(mocker, {"on_table_only": _column(int, "integer")})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=False)
+
+    kinds = {m.kind for m in mismatches}
+    assert kinds == {SchemaMismatchKind.MISSING_ON_TABLE, SchemaMismatchKind.MISSING_ON_MODEL}


### PR DESCRIPTION
## Summary

Related to #42. Stacked on #47. Tracked at #53.

Adds the schema-validation entry point and the enumeration-only error
paths (`MISSING_ON_TABLE`, `MISSING_ON_MODEL`). Per-field type
comparison is layered on in the next stacked PR (#48b); this PR is
intentionally scoped to "do columns line up", not "do their types
agree".

- `_validate_table_schema(model_cls, table, *, allow_extra_columns)`
  iterates the model's `model_fields` (excluding the base `id` /
  `name`) against the table's columns. Reports a `MISSING_ON_TABLE`
  mismatch for any model field with no matching column. When
  `allow_extra_columns=False`, reports `MISSING_ON_MODEL` for any
  column the model does not declare. Fields present on both sides are
  passed through silently — the next PR fills in the comparison.
- `model_type` is sourced from `info.annotation` and typed
  `TypeAnnotation` (from `fgmetric._typing_extensions`), so the
  literal annotation is preserved end-to-end. `column_type` is the
  SDK-resolved Python type on the `Column`.

**Design note (re your "why two layers" comment on the previous
revision):** the internal helper still returns `list[SchemaMismatch]`
because test introspection is much cleaner that way (no
`pytest.raises` ceremony to inspect per-field details). The classmethod
that raises lands in #49 and is a thin wrapper.

## Test plan

- `MISSING_ON_TABLE` populates `model_field` + `model_type` and leaves
  `column_*` `None`.
- `MISSING_ON_MODEL` populates `column_name` + `column_type` and
  leaves `model_*` `None`.
- `allow_extra_columns=True` silences `MISSING_ON_MODEL`.
- `id` / `name` model fields are skipped.
- Multiple mismatches are collected in one pass.

Co-Authored-By: Claude <noreply@anthropic.com>