### PR TITLE
feat(registry): expose validate_table_schema classmethod on LatchRecordModel

### DIFF
--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -9,6 +9,9 @@ from latch.registry.types import EmptyCell
 from latch.registry.types import InvalidValue
 from pydantic import BaseModel
 
+from fglatch.registry._schema import RegistryTableSchemaError
+from fglatch.registry._schema import _validate_table_schema
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,6 +122,41 @@ class LatchRecordModel(BaseModel):
         out_values["id"] = record.id
 
         return cls.model_validate(out_values)
+
+    @classmethod
+    def validate_table_schema(
+        cls,
+        table_id: str,
+        *,
+        allow_extra_columns: bool = True,
+    ) -> None:
+        """
+        Validate that a Registry table's schema matches this model's declared schema.
+
+        Fetches the table, compares its columns to the model's fields, and raises when
+        they disagree. Intended to be called at startup / in CI to catch schema drift
+        before data-level failures during `from_record`.
+
+        Args:
+            table_id: ID of the Registry table to validate against.
+            allow_extra_columns: If True (default), columns on the table that are not
+                declared on the model are silently accepted. If False, extra columns
+                produce `MISSING_ON_MODEL` mismatches.
+
+        Raises:
+            RegistryTableSchemaError: If the table's schema disagrees with the model's
+                schema. The exception's `mismatches` attribute carries one
+                `SchemaMismatch` per detected disagreement.
+        """
+        # `Table(id=...)` is a lightweight handle; `.load()` populates its columns from
+        # the Registry. The validator below calls `table.get_columns()`, which returns
+        # the empty dict on an un-loaded table — so the network round-trip on `.load()`
+        # is required for the validation to see anything.
+        table = Table(id=table_id)
+        table.load()
+        mismatches = _validate_table_schema(cls, table, allow_extra_columns=allow_extra_columns)
+        if mismatches:
+            raise RegistryTableSchemaError(mismatches)
 
 
 def _safe_table_name(table_id: str) -> str | None:

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -5,12 +5,16 @@ import pytest
 from latch.registry.record import Record
 from latch.registry.table import Table
 from latch.registry.table import TableNotFoundError
+from latch.registry.types import Column
 from latch.registry.types import EmptyCell
 from latch.registry.types import InvalidValue
+from latch.registry.upstream_types.types import DBType
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from fglatch.registry import LatchRecordModel
+from fglatch.registry import RegistryTableSchemaError
+from fglatch.registry import SchemaMismatchKind
 from fglatch.registry import query_latch_records_by_name
 from fglatch.registry._record_model import _classify_record_values
 from fglatch.registry._record_model import _safe_table_name
@@ -357,3 +361,68 @@ def test_classify_record_values(mocker: MockerFixture) -> None:
 
     assert len(empty_cells) == 1
     assert empty_cells[0] == "experiment_id"
+
+
+# LatchRecordModel.validate_table_schema classmethod.
+
+
+def _schema_fixture_column(key: str, py_type: type, primitive: str) -> Column:
+    """Minimal typed Column for validate_table_schema wiring tests."""
+    upstream_type: DBType = {
+        "type": {"primitive": primitive},  # type: ignore[typeddict-item]  # test fixture keeps primitive parametric
+        "allowEmpty": False,
+    }
+    return Column(key=key, type=py_type, upstream_type=upstream_type)
+
+
+def test_validate_table_schema_loads_and_succeeds(mocker: MockerFixture) -> None:
+    """The classmethod constructs a Table(id=...), calls load(), and succeeds on a match."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mock_table = mocker.MagicMock(spec=Table)
+    mock_table.get_columns.return_value = {"x": _schema_fixture_column("x", str, "string")}
+    mocker.patch("fglatch.registry._record_model.Table", return_value=mock_table)
+
+    Model.validate_table_schema("1234")
+
+    mock_table.load.assert_called_once()
+
+
+def test_validate_table_schema_raises_on_mismatch(mocker: MockerFixture) -> None:
+    """The classmethod raises RegistryTableSchemaError when the helper returns mismatches."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mock_table = mocker.MagicMock(spec=Table)
+    mock_table.get_columns.return_value = {}  # Model declares x, table has nothing.
+    mocker.patch("fglatch.registry._record_model.Table", return_value=mock_table)
+
+    with pytest.raises(RegistryTableSchemaError) as exc_info:
+        Model.validate_table_schema("1234")
+
+    assert len(exc_info.value.mismatches) == 1
+    assert exc_info.value.mismatches[0].kind is SchemaMismatchKind.MISSING_ON_TABLE
+    assert exc_info.value.mismatches[0].model_field == "x"
+
+
+def test_validate_table_schema_forwards_allow_extra_columns(mocker: MockerFixture) -> None:
+    """`allow_extra_columns=False` surfaces `MISSING_ON_MODEL` where the default is silent."""
+
+    class Model(LatchRecordModel):
+        pass
+
+    mock_table = mocker.MagicMock(spec=Table)
+    mock_table.get_columns.return_value = {
+        "unexpected": _schema_fixture_column("unexpected", str, "string")
+    }
+    mocker.patch("fglatch.registry._record_model.Table", return_value=mock_table)
+
+    # Default allow_extra_columns=True — silent.
+    Model.validate_table_schema("1234")
+
+    with pytest.raises(RegistryTableSchemaError) as exc_info:
+        Model.validate_table_schema("1234", allow_extra_columns=False)
+    assert exc_info.value.mismatches[0].kind is SchemaMismatchKind.MISSING_ON_MODEL


### PR DESCRIPTION
## Summary

Related to #42. Stacked on #54. Tracked at #53.

Wraps the internal `_validate_table_schema` helper in a classmethod so
subclasses can call `MyModel.validate_table_schema(table_id)` at
startup or in CI to fail fast on schema drift.

- Constructs `Table(id=table_id)` and calls `.load()`, which performs
  the network round-trip needed to populate the table's columns. The
  validator's `table.get_columns()` returns the empty dict on an
  un-loaded table, so the load is required (documented inline in the
  classmethod).
- Defaults `allow_extra_columns=True`. Pass `False` for strict 1:1
  checks (CI use).
- Raises `RegistryTableSchemaError` (carrying `list[SchemaMismatch]`
  on `.mismatches`) when the helper finds disagreements; returns
  `None` on a clean match.

**Why not collapse the two layers (re your earlier review question):**
the internal helper still returns `list[SchemaMismatch]` so tests can
introspect per-mismatch details without `pytest.raises` ceremony, and
so future non-raising consumers (e.g. workspace-wide drift reports)
can call the helper directly. The classmethod is the raising surface.

**Existing callers of `LatchRecordModel` are unaffected** — only a new
classmethod is added; no existing call sites change behavior.

## Test plan

- Happy path: classmethod calls `table.load()` exactly once and
  returns `None`.
- Mismatch path: raises `RegistryTableSchemaError` carrying a
  `MISSING_ON_TABLE` mismatch with the right field name.
- `allow_extra_columns=False` is forwarded to the helper and surfaces
  a `MISSING_ON_MODEL` where the default (`True`) is silent.

Co-Authored-By: Claude <noreply@anthropic.com>