### PR TITLE
feat(registry): validate array columns

### DIFF
--- a/fglatch/registry/_schema.py
+++ b/fglatch/registry/_schema.py
@@ -1,10 +1,12 @@
 from enum import Enum
 from enum import StrEnum
 from typing import TYPE_CHECKING
+from typing import get_args
 
 # TODO: switch to the public re-export once fgmetric promotes these symbols
 # out of `_typing_extensions`.
 from fgmetric._typing_extensions import TypeAnnotation
+from fgmetric._typing_extensions import is_list
 from fgmetric._typing_extensions import is_optional
 from fgmetric._typing_extensions import unpack_optional
 from latch.registry.table import Table
@@ -280,6 +282,9 @@ def _compare_unwrapped(
     if model_type is LatchFile or model_type is LatchDir:
         return _compare_blob(field_name, column_name, model_type, column_type)
 
+    if is_list(model_type):
+        return _compare_list(field_name, column_name, model_type, column_type)
+
     if model_type is column_type:
         return None
 
@@ -371,4 +376,49 @@ def _compare_blob(
         column_name=column_name,
         model_type=model_type,
         column_type=column_type,
+    )
+
+
+def _compare_list(
+    field_name: str,
+    column_name: str,
+    model_type: TypeAnnotation,
+    column_type: TypeAnnotation,
+) -> SchemaMismatch | None:
+    """
+    Compare a `list[T]` model field to a Registry array column.
+
+    Recurses on the element types through `_compare_unwrapped`, so any element kind
+    (primitive, enum, blob, link, or nested list) is handled by the top-level dispatch.
+    Element-level mismatches surface with the inner `kind` and a `[*]`-qualified
+    `model_field`; e.g. `list[MyEnum]` against an `array<enum>` with disagreeing
+    members produces an `ENUM_MEMBER_MISMATCH` with `model_field="xs[*]"`.
+
+    Nullability is validated at the column boundary (`_compare_field_to_column`), not
+    per-element — Registry arrays carry `allowEmpty` on the array itself.
+    """
+    if not is_list(column_type):
+        return SchemaMismatch(
+            kind=SchemaMismatchKind.TYPE_MISMATCH,
+            model_field=field_name,
+            column_name=column_name,
+            model_type=model_type,
+            column_type=column_type,
+        )
+
+    model_args = get_args(model_type)
+    column_args = get_args(column_type)
+    if len(model_args) != 1 or len(column_args) != 1:
+        # Defensive: list[T] always has one arg via get_args, and to_python_type returns
+        # List[T] with one arg. Falls through only on malformed inputs.
+        return SchemaMismatch(
+            kind=SchemaMismatchKind.TYPE_MISMATCH,
+            model_field=field_name,
+            column_name=column_name,
+            model_type=model_type,
+            column_type=column_type,
+        )
+
+    return _compare_unwrapped(
+        f"{field_name}[*]", f"{column_name}[*]", model_args[0], column_args[0]
     )

--- a/tests/registry/test_schema.py
+++ b/tests/registry/test_schema.py
@@ -34,6 +34,22 @@ def _column(py_type: Any, primitive: _BasicPrimitive, allow_empty: bool = False)
     return Column(key="<placeholder>", type=column_type, upstream_type=upstream_type)
 
 
+def _array_column(
+    element_py_type: type,
+    element_primitive: _BasicPrimitive,
+    allow_empty: bool = False,
+) -> Column:
+    """Build a Registry array Column with a primitive element type."""
+    column_type: Any = list[element_py_type]  # type: ignore[valid-type]  # mypy can't use a variable as a type parameter
+    if allow_empty:
+        column_type = Union[column_type, EmptyCell]
+    upstream_type: DBType = {
+        "type": {"array": {"primitive": element_primitive}},
+        "allowEmpty": allow_empty,
+    }
+    return Column(key="<placeholder>", type=column_type, upstream_type=upstream_type)
+
+
 def _blob_column(node_type: str | None, allow_empty: bool = False) -> Column:
     """
     Build a blob Column. `node_type` is set in metadata when non-None.
@@ -607,5 +623,166 @@ def test_nullable_latch_file_happy(mocker: MockerFixture) -> None:
         f: LatchFile | None = None
 
     table = _table(mocker, {"f": _blob_column("file", allow_empty=True)})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+# Array tests.
+
+
+def test_list_of_strings_happy(mocker: MockerFixture) -> None:
+    """`list[str]` on the model ↔ `array<string>` column validates cleanly."""
+
+    class Model(LatchRecordModel):
+        tags: list[str]
+
+    table = _table(mocker, {"tags": _array_column(str, "string")})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_list_of_ints_happy(mocker: MockerFixture) -> None:
+    """`list[int]` on the model ↔ `array<integer>` column validates cleanly."""
+
+    class Model(LatchRecordModel):
+        counts: list[int]
+
+    table = _table(mocker, {"counts": _array_column(int, "integer")})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_list_with_mismatched_primitive_element(mocker: MockerFixture) -> None:
+    """`list[str]` on the model but `array<integer>` column → element-level `TYPE_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        xs: list[str]
+
+    table = _table(mocker, {"xs": _array_column(int, "integer")})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=True)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.TYPE_MISMATCH
+    assert mismatches[0].model_field == "xs[*]"
+
+
+def test_list_of_enums_happy(mocker: MockerFixture) -> None:
+    """`list[StrEnum]` ↔ `array<enum>` with matching members validates cleanly."""
+
+    class Model(LatchRecordModel):
+        statuses: list[_Status]
+
+    enum_array_type: DBType = {
+        "type": {"array": {"primitive": "enum", "members": ["Alpha", "Beta", "Gamma"]}},
+        "allowEmpty": False,
+    }
+    statuses_col_type: Any = list[_Status]
+    statuses_col = Column(
+        key="statuses",
+        type=statuses_col_type,
+        upstream_type=enum_array_type,
+    )
+    table = _table(mocker, {"statuses": statuses_col})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_list_of_enums_member_mismatch_surfaces_as_enum_member_mismatch(
+    mocker: MockerFixture,
+) -> None:
+    """`list[Enum]` against `array<enum>` with disagreeing members → `ENUM_MEMBER_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        statuses: list[_StatusExtraMember]  # model has Alpha/Beta/Gamma/Delta
+
+    enum_array_type: DBType = {
+        "type": {"array": {"primitive": "enum", "members": ["Alpha", "Beta", "Gamma"]}},
+        "allowEmpty": False,
+    }
+    statuses_col_type: Any = list[_StatusExtraMember]
+    statuses_col = Column(
+        key="statuses",
+        type=statuses_col_type,
+        upstream_type=enum_array_type,
+    )
+    table = _table(mocker, {"statuses": statuses_col})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=True)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.ENUM_MEMBER_MISMATCH
+    assert mismatches[0].model_field == "statuses[*]"
+
+
+def test_list_of_blobs_happy(mocker: MockerFixture) -> None:
+    """`list[LatchFile]` ↔ `array<blob>` with file nodeType validates cleanly via recursion."""
+
+    class Model(LatchRecordModel):
+        files: list[LatchFile]
+
+    blob_array_type: DBType = {
+        "type": {"array": {"primitive": "blob", "metadata": {"nodeType": "file"}}},
+        "allowEmpty": False,
+    }
+    files_col_type: Any = list[LatchFile]
+    files_col = Column(
+        key="files",
+        type=files_col_type,
+        upstream_type=blob_array_type,
+    )
+    table = _table(mocker, {"files": files_col})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_list_of_blobs_subtype_mismatch_surfaces_as_blob_type_mismatch(
+    mocker: MockerFixture,
+) -> None:
+    """`list[LatchFile]` against `array<blob>` with dir nodeType → `BLOB_TYPE_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        files: list[LatchFile]
+
+    blob_array_type: DBType = {
+        "type": {"array": {"primitive": "blob", "metadata": {"nodeType": "dir"}}},
+        "allowEmpty": False,
+    }
+    files_col_type: Any = list[LatchFile]
+    files_col = Column(
+        key="files",
+        type=files_col_type,
+        upstream_type=blob_array_type,
+    )
+    table = _table(mocker, {"files": files_col})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=True)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.BLOB_TYPE_MISMATCH
+    assert mismatches[0].model_field == "files[*]"
+
+
+def test_list_type_mismatch_when_column_not_array(mocker: MockerFixture) -> None:
+    """`list[str]` on the model vs a primitive string column → `TYPE_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        xs: list[str]
+
+    table = _table(mocker, {"xs": _column(str, "string")})
+
+    mismatches = _validate_table_schema(Model, table, allow_extra_columns=True)
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.TYPE_MISMATCH
+
+
+def test_nullable_list_happy(mocker: MockerFixture) -> None:
+    """`list[str] | None` on the model ↔ nullable `array<string>` column validates cleanly."""
+
+    class Model(LatchRecordModel):
+        xs: list[str] | None = None
+
+    table = _table(mocker, {"xs": _array_column(str, "string", allow_empty=True)})
 
     assert _validate_table_schema(Model, table, allow_extra_columns=True) == []


### PR DESCRIPTION
## Summary

Related to #42. Stacked on #55. Tracked at #53.

Extends `_compare_unwrapped` with a dispatch branch for `list[T]`,
plus `_compare_list`.

- Uses `fgmetric._typing_extensions.is_list` to identify both sides as
  arrays (no more hand-rolled `get_origin(...) is list`).
- `_compare_list` recurses on element types via `_compare_unwrapped`,
  so any element kind (primitive, enum, blob, or nested list) is
  handled by the top-level dispatch. Element-level mismatches surface
  with the inner `kind` and a `[*]`-qualified `model_field` — e.g.
  `list[MyEnum]` against an `array<enum>` with disagreeing members
  produces an `ENUM_MEMBER_MISMATCH` with `model_field="statuses[*]"`.
- Nullability is enforced at the column boundary, not per-element,
  because Registry arrays carry `allowEmpty` on the array itself.

Split out of the original combined array+link PR per your request.
Link lands in #56.

## Test plan

- `list[str]` and `list[int]` happy paths.
- Primitive element type mismatch surfaces with `model_field="xs[*]"`.
- Recursion into enum element types: happy path and member-mismatch
  (`ENUM_MEMBER_MISMATCH` with `[*]`-qualified field name).
- Recursion into blob element types: happy path and subtype mismatch
  (`BLOB_TYPE_MISMATCH` with `[*]`-qualified field name).
- `list[str]` against a non-array column → `TYPE_MISMATCH`.
- `list[str] | None` ↔ nullable array column happy path.

Co-Authored-By: Claude <noreply@anthropic.com>