### PR TITLE
feat(registry): validate schema in from_record + integration tests

### DIFF
--- a/fglatch/registry/_record_model.py
+++ b/fglatch/registry/_record_model.py
@@ -61,6 +61,7 @@ class LatchRecordModel(BaseModel):
         table_id: str | None = None,
         exclude_empty_values: bool = False,
         exclude_invalid_values: bool = False,
+        validate_schema: bool = False,
     ) -> Self:
         """
         Create a validated model instance from a Latch Registry Record.
@@ -70,23 +71,36 @@ class LatchRecordModel(BaseModel):
 
         Args:
             record: A record retrieved from a Latch Registry table via the SDK.
-            table_id: An optional table ID to check the record against.
+            table_id: An optional table ID to check the record against. Required when
+                `validate_schema=True`.
             exclude_empty_values: If True, record attributes with value `EmptyCell` are excluded
                 prior to validation and a warning is logged.
             exclude_invalid_values: If True, record attributes with value `InvalidValue` are
                 excluded prior to validation and a warning is logged.
+            validate_schema: If True, run `validate_table_schema(table_id)` before decoding the
+                record's values. Fails loudly on schema drift. Requires `table_id` to be set.
+                Each call performs a network round-trip to reload the table — callers iterating
+                over many records should call `cls.validate_table_schema(table_id)` once up front
+                and then call `from_record` without this flag.
 
         Returns:
             A validated instance of the model with all field data populated.
 
         Raises:
             ValueError: If the record originates from a different table than the one specified by
-                `table_id`.
+                `table_id`, or if `validate_schema=True` without a `table_id`.
+            RegistryTableSchemaError: If `validate_schema=True` and the Registry table's schema
+                disagrees with this model's schema.
             ValidationError: If the record data fails model validation (e.g. missing required
                 fields, incorrect types).
         """
+        if validate_schema and table_id is None:
+            raise ValueError("`validate_schema=True` requires `table_id` to be set.")
+
         if table_id is not None:
             _validate_source_table(record, table_id)
+            if validate_schema:
+                cls.validate_table_schema(table_id)
 
         # Convert a Record to a dictionary.
         record_name: str = record.get_name()

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,5 +1,8 @@
 """Constants used by the test suite."""
 
+import os
+from typing import Final
+
 MOCK_TABLE_1_ID: str = "11730"
 """Identifier for mock-table-1."""
 
@@ -11,3 +14,19 @@ MOCK_RECORD_1_NAME: str = "DNA123/seq_abc"
 
 MOCK_LINKED_RECORD_NAME: str = "POOL456/sample_xyz"
 """Name for a mocked linked record value."""
+
+SCHEMA_FIXTURE_TABLE_ID: Final[str | None] = os.environ.get("FGLATCH_FIXTURE_TABLE_ID")
+"""
+ID of a Registry table used by the `test_schema_integration` integration tests.
+
+Expected column layout is documented at the top of that test file. When this env var is
+unset, the integration tests skip.
+"""
+
+SCHEMA_FIXTURE_LINKED_TABLE_ID: Final[str | None] = os.environ.get(
+    "FGLATCH_FIXTURE_LINKED_TABLE_ID"
+)
+"""
+ID of the companion Registry table pointed at by the fixture table's `link_col`. When this
+env var is unset, the integration tests skip.
+"""

--- a/tests/registry/test_record_model.py
+++ b/tests/registry/test_record_model.py
@@ -426,3 +426,65 @@ def test_validate_table_schema_forwards_allow_extra_columns(mocker: MockerFixtur
     with pytest.raises(RegistryTableSchemaError) as exc_info:
         Model.validate_table_schema("1234", allow_extra_columns=False)
     assert exc_info.value.mismatches[0].kind is SchemaMismatchKind.MISSING_ON_MODEL
+
+
+# from_record(validate_schema=True) integration.
+
+
+def test_from_record_validate_schema_happy(mocker: MockerFixture) -> None:
+    """`from_record(validate_schema=True)` succeeds when the table's schema matches."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "rec_id"
+    mock_record.get_name.return_value = "my_record"
+    mock_record.get_table_id.return_value = "tbl_id"
+    mock_record.get_values.return_value = {"x": "hello"}
+
+    mock_table = mocker.MagicMock(spec=Table)
+    mock_table.id = "tbl_id"
+    mock_table.get_display_name.return_value = "My Table"
+    mock_table.get_columns.return_value = {"x": _schema_fixture_column("x", str, "string")}
+    mocker.patch("fglatch.registry._record_model.Table", return_value=mock_table)
+
+    result = Model.from_record(mock_record, table_id="tbl_id", validate_schema=True)
+
+    assert result.x == "hello"
+
+
+def test_from_record_validate_schema_raises_on_mismatch(mocker: MockerFixture) -> None:
+    """`from_record(validate_schema=True)` raises when the schema doesn't match."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mock_record = mocker.MagicMock(spec=Record)
+    mock_record.id = "rec_id"
+    mock_record.get_name.return_value = "my_record"
+    mock_record.get_table_id.return_value = "tbl_id"
+    mock_record.get_values.return_value = {"x": "hello"}
+
+    mock_table = mocker.MagicMock(spec=Table)
+    mock_table.id = "tbl_id"
+    mock_table.get_display_name.return_value = "My Table"
+    mock_table.get_columns.return_value = {}  # model declares x, table has no columns
+    mocker.patch("fglatch.registry._record_model.Table", return_value=mock_table)
+
+    with pytest.raises(RegistryTableSchemaError):
+        Model.from_record(mock_record, table_id="tbl_id", validate_schema=True)
+
+
+def test_from_record_validate_schema_requires_table_id(mocker: MockerFixture) -> None:
+    """validate_schema=True without table_id raises ValueError (not RegistryTableSchemaError)."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mock_record = mocker.MagicMock(spec=Record)
+
+    with pytest.raises(ValueError) as exc_info:
+        Model.from_record(mock_record, validate_schema=True)
+
+    assert not isinstance(exc_info.value, RegistryTableSchemaError)

--- a/tests/registry/test_schema_integration.py
+++ b/tests/registry/test_schema_integration.py
@@ -1,0 +1,161 @@
+"""
+Integration tests for `LatchRecordModel.validate_table_schema`.
+
+These tests run against a live Registry table whose ID is read from the
+`FGLATCH_FIXTURE_TABLE_ID` environment variable (and `FGLATCH_FIXTURE_LINKED_TABLE_ID`
+for the companion table that `link_col` points at). They exist to confirm the SDK
+shapes (`Table.get_columns()`, `Column.type`, `Column.upstream_type`) haven't drifted
+out from under our validator. Per-kind error-branch coverage lives in
+`test_schema.py` (unit tests with mocked Columns).
+
+Fixture table column layout
+---------------------------
+
+The fixture table must be recreated in the Fulcrum Genomics Latch workspace if it
+is lost or the env var is pointed elsewhere. Columns:
+
+Primitives (`allowEmpty=False`):
+- `string_col`   : string
+- `int_col`      : integer
+- `float_col`    : number
+- `bool_col`     : boolean
+- `date_col`     : date
+- `datetime_col` : datetime
+
+Nullable primitives (`allowEmpty=True`):
+- `nullable_string_col` : string
+- `nullable_int_col`    : integer
+
+Blobs (both nodeType variants):
+- `file_col` : blob (metadata.nodeType = file)
+- `dir_col`  : blob (metadata.nodeType = dir)
+
+Enum:
+- `enum_col` : enum, members `["Alpha", "Beta", "Gamma"]` (identifier-mixed-case,
+  so the assertion that the model's `.value` matches the column's `.name` actually
+  exercises the comparison logic — same-case fixtures would let a name-on-both-sides
+  regression slip through)
+
+Arrays:
+- `string_array_col`        : array<string>
+- `nullable_int_array_col`  : array<integer>, allowEmpty
+
+Link:
+- `link_col` : link → the companion table referenced by
+  `FGLATCH_FIXTURE_LINKED_TABLE_ID`.
+
+The companion table needs no custom columns — the auto-provided Name column plus one
+placeholder record is enough for `link_col` to point somewhere valid.
+"""
+
+from datetime import date
+from datetime import datetime
+from enum import Enum
+
+import pytest
+from latch.types.directory import LatchDir
+from latch.types.file import LatchFile
+
+from fglatch.registry import LatchRecordModel
+from fglatch.registry import RegistryTableSchemaError
+from fglatch.registry import SchemaMismatchKind
+from tests.constants import SCHEMA_FIXTURE_TABLE_ID
+
+pytestmark = [
+    pytest.mark.requires_latch_registry,
+    pytest.mark.skipif(
+        SCHEMA_FIXTURE_TABLE_ID is None,
+        reason="FGLATCH_FIXTURE_TABLE_ID env var is not set",
+    ),
+]
+
+
+class _FixtureEnum(Enum):
+    """
+    Mirrors the fixture column's members with `.value` carrying the Registry string.
+
+    Uses identifier-uppercase + value-mixed-case (`ALPHA = "Alpha"`) so a regression to
+    name-on-both-sides comparison would fail this fixture — same-case pairs would let
+    the bug slip through silently.
+    """
+
+    ALPHA = "Alpha"
+    BETA = "Beta"
+    GAMMA = "Gamma"
+
+
+class FullFixtureModel(LatchRecordModel):
+    """A 1:1 model mirroring the fixture table's column layout."""
+
+    string_col: str
+    int_col: int
+    float_col: float
+    bool_col: bool
+    date_col: date
+    datetime_col: datetime
+    nullable_string_col: str | None = None
+    nullable_int_col: int | None = None
+    file_col: LatchFile
+    dir_col: LatchDir
+    enum_col: _FixtureEnum
+    string_array_col: list[str]
+    nullable_int_array_col: list[int] | None = None
+    link_col: LatchRecordModel
+
+
+class PrunedFixtureModel(LatchRecordModel):
+    """Declares only a subset of the fixture table's columns."""
+
+    string_col: str
+    int_col: int
+
+
+class ExtraFieldFixtureModel(LatchRecordModel):
+    """Declares a field that the fixture table does not have."""
+
+    string_col: str
+    not_on_table: str
+
+
+def test_full_model_matches_fixture_table() -> None:
+    """A 1:1 model validates cleanly against the live fixture table."""
+    assert SCHEMA_FIXTURE_TABLE_ID is not None
+    FullFixtureModel.validate_table_schema(SCHEMA_FIXTURE_TABLE_ID)
+
+
+def test_full_model_matches_fixture_table_strict() -> None:
+    """The 1:1 model also validates with `allow_extra_columns=False`."""
+    assert SCHEMA_FIXTURE_TABLE_ID is not None
+    FullFixtureModel.validate_table_schema(SCHEMA_FIXTURE_TABLE_ID, allow_extra_columns=False)
+
+
+def test_pruned_model_passes_when_extras_allowed() -> None:
+    """A model declaring a subset of columns passes when `allow_extra_columns=True`."""
+    assert SCHEMA_FIXTURE_TABLE_ID is not None
+    PrunedFixtureModel.validate_table_schema(SCHEMA_FIXTURE_TABLE_ID)
+
+
+def test_pruned_model_fails_when_extras_disallowed() -> None:
+    """A pruned model fails with `missing_on_model` when `allow_extra_columns=False`."""
+    assert SCHEMA_FIXTURE_TABLE_ID is not None
+    with pytest.raises(RegistryTableSchemaError) as exc_info:
+        PrunedFixtureModel.validate_table_schema(SCHEMA_FIXTURE_TABLE_ID, allow_extra_columns=False)
+    kinds = {m.kind for m in exc_info.value.mismatches}
+    assert kinds == {SchemaMismatchKind.MISSING_ON_MODEL}
+
+
+def test_extra_field_on_model_always_fails() -> None:
+    """A model with a field not on the table fails with `missing_on_table` regardless of flag."""
+    assert SCHEMA_FIXTURE_TABLE_ID is not None
+
+    for allow_extra in (True, False):
+        with pytest.raises(RegistryTableSchemaError) as exc_info:
+            ExtraFieldFixtureModel.validate_table_schema(
+                SCHEMA_FIXTURE_TABLE_ID, allow_extra_columns=allow_extra
+            )
+        missing_on_table_fields = {
+            m.model_field
+            for m in exc_info.value.mismatches
+            if m.kind is SchemaMismatchKind.MISSING_ON_TABLE
+        }
+        assert "not_on_table" in missing_on_table_fields


### PR DESCRIPTION
## Summary

Related to #42. Stacked on #56. Tracked at #53. Completes the stack.

Adds the final ergonomic affordance and the live-SDK smoke tests.

- `from_record(..., validate_schema=False)` flag that runs
  `validate_table_schema(table_id)` before decoding record values, so
  schema drift fails loudly (with structured `SchemaMismatch`) rather
  than mid-decode (with per-value `ValidationError`). Requires
  `table_id` — guards against silently doing nothing when called
  without one. Each call performs a network round-trip; callers
  iterating many records should call `cls.validate_table_schema(...)`
  once up front and pass `validate_schema=False` to subsequent calls.
- Integration tests gated on `FGLATCH_FIXTURE_TABLE_ID` /
  `FGLATCH_FIXTURE_LINKED_TABLE_ID` env vars (skip when unset). They
  exercise the four scenarios in the spec — full match, pruned model
  with extras allowed/disallowed, and model-has-extra-field — against
  a live Registry table. The fixture's column layout is documented at
  the top of the test file so the table can be recreated if lost.

**Existing `from_record` callers are unaffected** — `validate_schema`
defaults to `False`, and `RegistryTableSchemaError` subclasses
`ValueError` so any existing `except ValueError` paths still catch.

## Test plan

- Unit: `from_record(validate_schema=True)` happy path, raises
  `RegistryTableSchemaError` on mismatch, and `ValueError` (not the
  schema error) when called without `table_id`.
- Integration (env-gated): 1:1 fixture model passes both with and
  without `allow_extra_columns=False`; pruned model passes when extras
  are allowed and fails with `MISSING_ON_MODEL` when they aren't; a
  model with a field not on the table fails with `MISSING_ON_TABLE`
  regardless of the flag. Skips until env vars are set.

Co-Authored-By: Claude <noreply@anthropic.com>