### PR TITLE
Tracker: validate_table_schema decomposition (#47-#52)

### DIFF
--- a/agent_notes/2026-05-21_validate-table-schema-tracker.md
+++ b/agent_notes/2026-05-21_validate-table-schema-tracker.md
@@ -22,9 +22,9 @@ Each child PR is stacked on the previous one. Mark complete when merged.
 
 ## Cross-cutting refactors (apply across the whole stack)
 
-- [ ] **Drop `Any` where possible.** Use `TypeAnnotation` (from `fgmetric._typing_extensions` — to be promoted to the public API by @msto) for model annotations.
-- [ ] **Reuse `fgmetric` type introspection.** Replace `_is_nullable` → `is_optional`, `_unwrap_none` → `unpack_optional`, list checks → `is_list` / `has_origin`. Adds `fgmetric>=0.3` as a runtime dependency.
-- [ ] **Rename `expected` / `actual` on `SchemaMismatch`.** Both names are ambiguous — "expected by whom?" Rename to `model_type` / `column_type` (and similarly for the `field` / `column_name` distinction in the missing/extra cases). Update messages.
+- [ ] **Drop `Any` where possible.** Use `TypeAnnotation` (imported from `fgmetric._typing_extensions` — private import for now; TODO: switch to the public API once @msto promotes it).
+- [ ] **Reuse `fgmetric` type introspection.** Replace `_is_nullable` → `is_optional`, `_unwrap_none` → `unpack_optional`, list checks → `is_list` / `has_origin`. Adds `fgmetric>=0.3` as a runtime dep. (Possible future extraction into a dedicated `fgtyping` package — trigger is the second non-metric consumer.)
+- [ ] **Rename `expected` / `actual` on `SchemaMismatch`.** Both names are ambiguous — "expected by whom?" New schema: two optional fields, `model_type: TypeAnnotation | None` and `column_type: TypeAnnotation | None`, plus two optional name fields, `model_field: str | None` and `column_name: str | None`. Which slots are populated depends on `kind`. Messages derive from whatever is populated.
 
 ## Per-PR review fixes
 
@@ -54,7 +54,8 @@ Each child PR is stacked on the previous one. Mark complete when merged.
 
 ### #50a — enum (split from #50)
 
-- [ ] Compare enum members by `.value`, not `.name`, when the model's enum is value-typed. Current `.name` comparison is wrong for `StrEnum`-style enums where values carry the Registry strings. Validate the assumption in the SDK source.
+- [ ] Fix enum comparison. SDK constructs the column's type as `Enum("Enum", members)`, which puts the Registry strings in `.name` and auto-ints in `.value`. The model side (Python convention) puts the Python identifier in `.name` (e.g. `"FOO"`) and the user-assigned string in `.value` (e.g. `"Foo"`). Correct comparison: **Registry `.name` ↔ Model `.value`**. The current test fixture happened to use identifiers identical to values (`ALPHA = "ALPHA"`), masking the bug.
+- [ ] Decide how to handle `auto()`-valued model enums (where `.value` is a meaningless int): either reject them with a clear error, or fall back to `.name`-on-both-sides with a documented caveat. Recommend rejection — the user should be explicit about which string the enum maps to.
 - [ ] Rename `expected`/`actual` per cross-cutting item.
 
 ### #50b — blob (new, split from #50)

--- a/agent_notes/2026-05-21_validate-table-schema-tracker.md
+++ b/agent_notes/2026-05-21_validate-table-schema-tracker.md
@@ -1,0 +1,79 @@
+# Tracker: `LatchRecordModel.validate_table_schema` — stacked PR series
+
+Closes #42 when the whole stack lands.
+
+This is a tracking document. It is **not** intended to merge — leave the PR as draft and close it once every child PR lands.
+
+## Stack
+
+Each child PR is stacked on the previous one. Mark complete when merged.
+
+- [x] **#47** — `feat(registry): add schema validation error types` (~130 lines, base: `main`)
+- [ ] **#48a** — `feat(registry): add schema validation dispatcher + missing/extra columns` (~170 lines, base: #47)
+- [ ] **#48b** — `feat(registry): compare primitive types and nullability` (~210 lines, base: #48a)
+- [ ] **#49** — `feat(registry): expose validate_table_schema classmethod on LatchRecordModel` (~105 lines, base: #48b)
+- [ ] **#50a** — `feat(registry): validate enum columns` (~170 lines, base: #49)
+- [ ] **#50b** — `feat(registry): validate blob columns` (~170 lines, base: #50a)
+- [ ] **#51a** — `feat(registry): validate array columns` (~210 lines, base: #50b)
+- [ ] **#51b** — `feat(registry): validate link columns` (~110 lines, base: #51a)
+- [ ] **#52** — `feat(registry): validate schema in from_record + integration tests` (~250 lines, base: #51b)
+
+`#48` originally bundled the dispatcher + nullability + primitive comparison; per @msto, decomposed into #48a (enumerate fields) and #48b (compare types). `#50` and `#51` split per-column-kind.
+
+## Cross-cutting refactors (apply across the whole stack)
+
+- [ ] **Drop `Any` where possible.** Use `TypeAnnotation` (from `fgmetric._typing_extensions` — to be promoted to the public API by @msto) for model annotations.
+- [ ] **Reuse `fgmetric` type introspection.** Replace `_is_nullable` → `is_optional`, `_unwrap_none` → `unpack_optional`, list checks → `is_list` / `has_origin`. Adds `fgmetric>=0.3` as a runtime dependency.
+- [ ] **Rename `expected` / `actual` on `SchemaMismatch`.** Both names are ambiguous — "expected by whom?" Rename to `model_type` / `column_type` (and similarly for the `field` / `column_name` distinction in the missing/extra cases). Update messages.
+
+## Per-PR review fixes
+
+### #47 — error types
+
+- [ ] Convert `SchemaMismatch.kind` from `Literal[...]` to a `StrEnum` (declared as a nested class variable on `SchemaMismatch` for discoverability).
+- [ ] Make `SchemaMismatch.message` a Pydantic computed field, dispatched on `kind` (and on the kind StrEnum). No more caller-supplied messages.
+- [ ] Tests: drop `test_schema_mismatch_constructs` (just exercises `BaseModel.__init__`) and `test_registry_table_schema_error_carries_mismatches` (same). Keep `test_registry_table_schema_error_is_value_error` but pass an empty `mismatches=[]`. Add a test that asserts the computed `message` content per kind.
+
+### #48a — dispatcher + missing/extra (split from #48)
+
+- [ ] Replace `_is_nullable` / `_unwrap_none` with `fgmetric.is_optional` / `unpack_optional`.
+- [ ] Replace `Any` with `TypeAnnotation` on the dispatcher's signatures.
+- [ ] Drop the `_describe_type` helper — keep literal annotation strings everywhere (per @msto: "explicit is better than implicit").
+- [ ] Drop the `_type_mismatch` helper — `SchemaMismatch` derives `message` itself from `kind` + types.
+- [ ] Re-evaluate the `TYPE_CHECKING`-only forward ref `"type[LatchRecordModel]"` on `_validate_table_schema` — drop if unnecessary.
+
+### #48b — primitive + nullability (new, split from #48)
+
+- [ ] Decide whether `_compare_field_to_column` / `_compare_unwrapped` should return `SchemaMismatch | None` instead of `list[SchemaMismatch]`. They never return >1; the list shape was just for `.extend()` ergonomics.
+- [ ] Guard against missing `allowEmpty` key on the upstream type dict (or document that the SDK always populates it).
+
+### #49 — classmethod
+
+- [ ] Confirm whether `table.load()` is required, and what it does (network round-trip? cache?). Drop or document.
+- [ ] Reconsider raise-via-classmethod vs `_validate_table_schema` raising directly. If the helper raises, the classmethod is a one-liner.
+
+### #50a — enum (split from #50)
+
+- [ ] Compare enum members by `.value`, not `.name`, when the model's enum is value-typed. Current `.name` comparison is wrong for `StrEnum`-style enums where values carry the Registry strings. Validate the assumption in the SDK source.
+- [ ] Rename `expected`/`actual` per cross-cutting item.
+
+### #50b — blob (new, split from #50)
+
+- [ ] No additional notes beyond cross-cutting items.
+
+### #51a — array (split from #51)
+
+- [ ] Use `fgmetric.is_list` / `has_origin` for the list check.
+- [ ] Use `fgmetric.has_optional_elements` if it simplifies the element-nullability decision.
+
+### #51b — link (new, split from #51)
+
+- [ ] Drop the local-import dance in `_is_latch_record_model_subclass` if a structural check (e.g. `isinstance(t, type) and hasattr(t, "model_fields")` or a `Protocol`) works.
+
+### #52 — `from_record` + integration
+
+- [ ] Confirm the integration fixture is provisioned and the env vars are documented in the README.
+
+## Backup
+
+Original linear history of `feat/validate-table-schema` is preserved locally as `backup/feat-validate-table-schema-orig` (not pushed). Restore from there if a rebase goes sideways.


### PR DESCRIPTION
**Do not merge.** This PR is a tracker for the `validate_table_schema` stack; close it when every child PR has merged.

Related to #42.

## Stack (in stack order)

- [ ] #47 — feat(registry): add schema validation error types
- [ ] #48 — feat(registry): add schema validation dispatcher + missing/extra columns
- [ ] #54 — feat(registry): compare primitive types and nullability against table
- [ ] #49 — feat(registry): expose validate_table_schema classmethod on LatchRecordModel
- [ ] #50 — feat(registry): validate enum columns
- [ ] #55 — feat(registry): validate blob columns
- [ ] #51 — feat(registry): validate array columns
- [ ] #56 — feat(registry): validate link columns
- [ ] #52 — feat(registry): validate schema in from_record + integration tests

The original three combined PRs (#48 primitives, #50 enum+blob, #51 array+link) were each split into two so every child PR is ≤400 lines. The full per-PR review-fix checklist lives in `agent_notes/2026-05-21_validate-table-schema-tracker.md`.

## Cross-cutting refactors (applied across the stack)

- [x] Drop `Any` for `TypeAnnotation` (imported from `fgmetric._typing_extensions`).
- [x] Reuse `fgmetric` type introspection: `is_optional` / `unpack_optional` / `is_list`. Adds `fgmetric>=0.3,<1` as a runtime dep.
- [x] Rename `expected` / `actual` on `SchemaMismatch` → two pairs of optional fields, `model_field` / `column_name` and `model_type` / `column_type`, populated by `kind`.
- [x] `SchemaMismatchKind` is a `StrEnum`; `SchemaMismatch.message` is a Pydantic `@computed_field` dispatched on `kind`. Callers never construct messages.
- [x] Comparators return `SchemaMismatch | None` (was `list[SchemaMismatch]`); only the top-level `_validate_table_schema` returns a list (batch report).
- [x] Enum comparison fixed: Registry `.name` ↔ Model `.value` (model values carry the user-assigned strings; the previous `.name`-on-both-sides comparison only worked because the test fixture used identifier=value pairs).
- [x] Structural check `_looks_like_latch_record_model` replaces the lazy-import-from-`_record_model` dance.
- [x] `_validate_table_schema` defaults missing `allowEmpty` to `False` (defensive — the SDK TypedDict requires it but a malformed payload shouldn't crash validation).

## Per-PR review fixes

Highlights of what changed in this round of revisions, by PR:

- **#47:** `SchemaMismatchKind` is a `StrEnum` with a docstring `Members:` block; `message` is a Pydantic `@computed_field`; `RegistryTableSchemaError.mismatches` is declared as a class-level annotation; trivial \"does BaseModel construct?\" tests dropped.
- **#48:** dispatcher is enumeration-only (`MISSING_ON_TABLE` / `MISSING_ON_MODEL`); no type comparison.
- **#54** *(new — split from #48):* primitive + nullability comparison; uses `fgmetric.is_optional` / `unpack_optional`; defensive `allowEmpty` default.
- **#49:** classmethod is a thin wrapper that calls `_validate_table_schema` and raises if non-empty. Two-layer design defended in the PR body — list-return is for test introspection + future non-raising consumers.
- **#50:** enum-only; comparison fix to Registry `.name` ↔ Model `.value`; tests use realistic identifier!=value fixtures.
- **#55** *(new — split from #50):* blob (`LatchFile` / `LatchDir`).
- **#51:** array-only; uses `fgmetric.is_list`.
- **#56** *(new — split from #51):* link; structural check for `LatchRecordModel`-shaped types.
- **#52:** `from_record(validate_schema=True)` + env-gated integration tests; rebased onto the new stack.

## Test plan

- [ ] When each child PR merges, tick its checkbox above and in the tracker doc.
- [ ] When the stack lands, close (don't merge) this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)