### PR TITLE
feat(registry): compare primitive types and nullability against table

### DIFF
--- a/fglatch/registry/_schema.py
+++ b/fglatch/registry/_schema.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING
 # TODO: switch to the public re-export once fgmetric promotes these symbols
 # out of `_typing_extensions`.
 from fgmetric._typing_extensions import TypeAnnotation
+from fgmetric._typing_extensions import is_optional
+from fgmetric._typing_extensions import unpack_optional
 from latch.registry.table import Table
+from latch.registry.types import Column
+from latch.registry.utils import to_python_type
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import computed_field
@@ -197,6 +201,10 @@ def _validate_table_schema(
                     model_type=annotation,
                 )
             )
+            continue
+        mismatch = _compare_field_to_column(field_name, annotation, columns[field_name])
+        if mismatch is not None:
+            mismatches.append(mismatch)
 
     if not allow_extra_columns:
         for column_name, column in columns.items():
@@ -211,3 +219,65 @@ def _validate_table_schema(
             )
 
     return mismatches
+
+
+def _compare_field_to_column(
+    field_name: str,
+    model_annotation: TypeAnnotation,
+    column: Column,
+) -> SchemaMismatch | None:
+    """
+    Compare one model field's annotation to one Registry `Column`.
+
+    Resolves nullability against the column's `allowEmpty` first; if the two
+    disagree, returns a `NULLABILITY_MISMATCH`. Otherwise, unwraps `T | None`
+    on both sides and defers the unwrapped comparison to `_compare_unwrapped`.
+
+    The `allowEmpty` key is defensively defaulted to `False` ("required") if
+    absent — the SDK's TypedDict marks it as required, but a malformed payload
+    shouldn't crash validation.
+    """
+    model_is_nullable = is_optional(model_annotation)
+    column_is_nullable: bool = column.upstream_type.get("allowEmpty", False)
+    column_python_type = to_python_type(column.upstream_type["type"])
+
+    if model_is_nullable != column_is_nullable:
+        return SchemaMismatch(
+            kind=SchemaMismatchKind.NULLABILITY_MISMATCH,
+            model_field=field_name,
+            column_name=column.key,
+            model_type=model_annotation,
+            column_type=column_python_type,
+        )
+
+    expected_type = unpack_optional(model_annotation) if model_is_nullable else model_annotation
+    return _compare_unwrapped(field_name, column.key, expected_type, column_python_type)
+
+
+def _compare_unwrapped(
+    field_name: str,
+    column_name: str,
+    model_type: TypeAnnotation,
+    column_type: TypeAnnotation,
+) -> SchemaMismatch | None:
+    """
+    Compare a pre-unwrapped model type to a pre-unwrapped column type.
+
+    Both inputs have already had `T | None` / `Union[T, EmptyCell]` stripped at the
+    caller. Primitive identity is the comparison performed here; richer dispatch
+    branches (enums, blobs, arrays, links) are added by subsequent helpers in the
+    same module.
+    """
+    # TODO: union columns (Latch `to_python_type` returns `Union[A, B]` for non-None
+    # unions) fall through this dispatch and produce a confusing `TYPE_MISMATCH`. Add
+    # explicit detection + a dedicated mismatch kind, or document the limitation.
+    if model_type is column_type:
+        return None
+
+    return SchemaMismatch(
+        kind=SchemaMismatchKind.TYPE_MISMATCH,
+        model_field=field_name,
+        column_name=column_name,
+        model_type=model_type,
+        column_type=column_type,
+    )

--- a/tests/registry/test_schema.py
+++ b/tests/registry/test_schema.py
@@ -227,3 +227,116 @@ def test_multiple_mismatches_collected(mocker: MockerFixture) -> None:
 
     kinds = {m.kind for m in mismatches}
     assert kinds == {SchemaMismatchKind.MISSING_ON_TABLE, SchemaMismatchKind.MISSING_ON_MODEL}
+
+
+# _validate_table_schema tests — primitive comparison and nullability.
+
+
+def test_validate_all_primitives_happy(mocker: MockerFixture) -> None:
+    """A model with each supported primitive matches a correspondingly-typed table."""
+    from datetime import date
+    from datetime import datetime
+
+    class Model(LatchRecordModel):
+        string_col: str
+        int_col: int
+        float_col: float
+        bool_col: bool
+        date_col: date
+        datetime_col: datetime
+
+    table = _table(
+        mocker,
+        {
+            "string_col": _column(str, "string"),
+            "int_col": _column(int, "integer"),
+            "float_col": _column(float, "number"),
+            "bool_col": _column(bool, "boolean"),
+            "date_col": _column(date, "date"),
+            "datetime_col": _column(datetime, "datetime"),
+        },
+    )
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_type_mismatch_emits_type_mismatch(mocker: MockerFixture) -> None:
+    """Model field type differs from the column's primitive → `TYPE_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mismatches = _validate_table_schema(
+        Model,
+        _table(mocker, {"x": _column(int, "integer")}),
+        allow_extra_columns=True,
+    )
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.TYPE_MISMATCH
+    assert mismatches[0].model_field == "x"
+    assert mismatches[0].column_name == "x"
+    assert mismatches[0].model_type is str
+    assert mismatches[0].column_type is int
+
+
+def test_nullable_field_matches_allow_empty_column(mocker: MockerFixture) -> None:
+    """`T | None` on the model matches `allowEmpty=True` on the column."""
+
+    class Model(LatchRecordModel):
+        maybe_str: str | None = None
+
+    table = _table(mocker, {"maybe_str": _column(str, "string", allow_empty=True)})
+
+    assert _validate_table_schema(Model, table, allow_extra_columns=True) == []
+
+
+def test_nullability_mismatch_model_nullable_column_required(mocker: MockerFixture) -> None:
+    """Model declares `T | None` but the column is required → `NULLABILITY_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        x: str | None = None
+
+    mismatches = _validate_table_schema(
+        Model,
+        _table(mocker, {"x": _column(str, "string", allow_empty=False)}),
+        allow_extra_columns=True,
+    )
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.NULLABILITY_MISMATCH
+
+
+def test_nullability_mismatch_model_required_column_nullable(mocker: MockerFixture) -> None:
+    """Model declares `T` but the column is nullable → `NULLABILITY_MISMATCH`."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    mismatches = _validate_table_schema(
+        Model,
+        _table(mocker, {"x": _column(str, "string", allow_empty=True)}),
+        allow_extra_columns=True,
+    )
+
+    assert len(mismatches) == 1
+    assert mismatches[0].kind is SchemaMismatchKind.NULLABILITY_MISMATCH
+
+
+def test_missing_allow_empty_defaults_to_required(mocker: MockerFixture) -> None:
+    """A column whose upstream_type lacks `allowEmpty` is treated as required (defensive)."""
+
+    class Model(LatchRecordModel):
+        x: str
+
+    upstream_type: DBType = {"type": {"primitive": "string"}}  # type: ignore[typeddict-item]  # intentionally omits allowEmpty
+    column = Column(key="x", type=str, upstream_type=upstream_type)
+
+    mismatches = _validate_table_schema(
+        Model,
+        _table(mocker, {"x": column}),
+        allow_extra_columns=True,
+    )
+
+    # Model is required (no `| None`); column treated as required → no mismatch.
+    assert mismatches == []


### PR DESCRIPTION
## Summary

Related to #42. Stacked on #48. Tracked at #53.

Layers per-field type comparison on top of the enumeration dispatcher
added in #48. Each model field that has a matching column is now
compared in two stages:

- `_compare_field_to_column`: checks nullability first using
  `fgmetric._typing_extensions.is_optional` / `unpack_optional`,
  cross-referenced against the column's `allowEmpty`. Disagreement →
  `NULLABILITY_MISMATCH` (carrying both sides' types in the message).
  Otherwise unwraps the optional on both sides and forwards to the
  inner comparator.
- `_compare_unwrapped`: primitive identity check on the unwrapped
  types (column's Python type comes from the SDK's `to_python_type`).
  Returns `TYPE_MISMATCH` on disagreement. Subsequent stacked PRs
  extend this dispatcher with enum / blob / array / link branches.

**Per your previous "list-shape vs Optional" comment:** comparators
now return `SchemaMismatch | None`. The caller hoists the `None`
check inline. (The top-level `_validate_table_schema` still returns
`list[SchemaMismatch]` for batch reporting — only the per-field
comparators were single-result.)

**Per your "missing allowEmpty?" comment:** the lookup defaults to
`False` when absent. The SDK's `DBType` marks it required, but a
malformed payload shouldn't crash validation. Dedicated test confirms
this defensive default.

## Test plan

- All six supported primitives validate as a single happy-path model.
- Primitive `TYPE_MISMATCH` populates both sides' types and field
  names on the resulting `SchemaMismatch`.
- Nullability: `T | None` ↔ `allowEmpty=True` happy path, plus
  `NULLABILITY_MISMATCH` in both directions (model nullable + column
  required, and vice versa).
- A column with no `allowEmpty` key is treated as required (defensive
  default).

Co-Authored-By: Claude <noreply@anthropic.com>